### PR TITLE
fix(usb-device): Optimize notification logic when device attachment f…

### DIFF
--- a/wsl-usb-manager/Domain/USBDeviceInfoModel.cs
+++ b/wsl-usb-manager/Domain/USBDeviceInfoModel.cs
@@ -214,10 +214,7 @@ public class USBDeviceInfoModel : ViewModelBase
         UpdateDeviceInfo();
         if (!Device.IsAttached)
         {
-            if (IsAutoAttach)
-                NotifyService.ShowNotification(ErrMsg);
-            else
-                NotifyService.ShowUSBIPDError(ErrorCode.DeviceAttachFailed, ErrMsg, Device);
+            NotifyService.ShowUSBIPDError(ErrorCode.DeviceAttachFailed, ErrMsg, Device);
         }
         
         return IsAttached;

--- a/wsl-usb-manager/USBIPD/USBDevice.cs
+++ b/wsl-usb-manager/USBIPD/USBDevice.cs
@@ -245,11 +245,10 @@ public sealed class USBDevice
         {
             return (true, $"Device({id}) is already unbound.");
         }
-        var (ErrCode, ErrMsg) = await USBIPDWin.DetachDevice(id, useBusID);
+        var (_, ErrMsg) = await USBIPDWin.DetachDevice(id, useBusID);
         await Update();
-        if (ErrCode == ErrorCode.Success)
+        if (!IsAttached)
         {
-            IsAttached = false;
             log.Info($"Success to detach {Description}({id}) from WSL.");
         }
         else


### PR DESCRIPTION
…ails

Remove redundant IsAutoAttach checks and uniformly use ShowUSBIPDError method to display error messages Fix status update issues when attempting to detach already attached devices to ensure IsAttached status correctly reflects actual attachment status Enhance logging and error handling after USBIPD command execution, adding detection and notification for situations with no running WSL2 distributions Clean up unused namespace references and adjust code indentation to improve readability