### PR TITLE
refactor: Remove the force parameter from the Attach method and optim…

### DIFF
--- a/wsl-usb-manager/Domain/USBDeviceInfoModel.cs
+++ b/wsl-usb-manager/Domain/USBDeviceInfoModel.cs
@@ -172,7 +172,7 @@ public class USBDeviceInfoModel : ViewModelBase
         return (!IsBound);
     }
 
-    public async Task<bool> Attach(bool force)
+    public async Task<bool> Attach()
       {
         string? ip = null, ErrMsg;
         string name = string.IsNullOrWhiteSpace(Device.Description) ? Device.HardwareId : Device.Description.Split(",", StringSplitOptions.RemoveEmptyEntries)[0];
@@ -210,9 +210,9 @@ public class USBDeviceInfoModel : ViewModelBase
             }
         }
 
-        (_, ErrMsg) = await Device.Attach(App.GetAppConfig().UseBusID, force, ip, IsAutoAttach);
+        (_, ErrMsg) = await Device.Attach(App.GetAppConfig().UseBusID, ip, IsAutoAttach);
         UpdateDeviceInfo();
-        if (!Device.IsAttached)
+        if (!Device.IsAttached && !string.IsNullOrEmpty(ErrMsg))
         {
             NotifyService.ShowUSBIPDError(ErrorCode.DeviceAttachFailed, ErrMsg, Device);
         }
@@ -220,14 +220,12 @@ public class USBDeviceInfoModel : ViewModelBase
         return IsAttached;
     }
 
-    public async Task<bool> Attach() => await Attach(false);
-
     public async Task<bool> Detach()
     {
         string name = string.IsNullOrWhiteSpace(Device.Description) ? Device.HardwareId : Device.Description.Split(",", StringSplitOptions.RemoveEmptyEntries)[0];
         var (Success, ErrMsg) = await Device.Detach(App.GetAppConfig().UseBusID);
         UpdateDeviceInfo();
-        if (!Success)
+        if (!Success && !string.IsNullOrEmpty(ErrMsg))
         {
             NotifyService.ShowErrorMessage($"Failed to detach '{name}': {ErrMsg}");
         }

--- a/wsl-usb-manager/USBDevices/USBDevicesView.xaml.cs
+++ b/wsl-usb-manager/USBDevices/USBDevicesView.xaml.cs
@@ -83,7 +83,7 @@ public partial class USBDevicesView : System.Windows.Controls.UserControl
                 NotifyService.DisableWindow();
                 if (device.IsAttached)
                 {
-                    await device.Attach(true);
+                    await device.Attach();
                 }
                 else
                 {
@@ -146,7 +146,7 @@ public partial class USBDevicesView : System.Windows.Controls.UserControl
                         await device.Unbind();
                         break;
                     case "MenuItemAttach":
-                        await device.Attach(true);
+                        await device.Attach();
                         break;
                     case "MenuItemDetach":
                         await device.Detach();

--- a/wsl-usb-manager/USBIPD/USBDevice.cs
+++ b/wsl-usb-manager/USBIPD/USBDevice.cs
@@ -159,7 +159,7 @@ public sealed class USBDevice
         {
             log.Info($"Success to bind {Description}({id}){(IsForced ? " forcibly" : "")}.");
         }
-        else
+        else if (ret.ErrCode != ErrorCode.Success)
         {
             log.Error($"Failed to bind {Description}({id}){(IsForced ? " forcibly" : "")}: {ret.ErrMsg}");
         }
@@ -179,20 +179,21 @@ public sealed class USBDevice
         }
 
         var (ErrCode, ErrMsg) = await USBIPDWin.UnbindDevice(id, useBusID);
-
-        if (ErrCode == ErrorCode.Success)
+        await Task.Delay(500);
+        await Update();
+        if (!IsBound)
         {
             IsBound = false;
             log.Info($"Success to unbind {Description}({id}).");
         }
-        else
+        else if (ErrCode != ErrorCode.Success)
         {
             log.Error($"Failed to unbind {Description}({id}): {ErrMsg}");
         }
         return (!IsBound, ErrMsg);
     }
 
-    public async Task<(bool Success, string ErrMsg)> Attach(bool useBusID,bool force, string? hostIP, bool isAuto)
+    public async Task<(bool Success, string ErrMsg)> Attach(bool useBusID, string? hostIP, bool isAuto)
     {
         string id = useBusID ? BusId : HardwareId;
 
@@ -216,13 +217,14 @@ public sealed class USBDevice
             return (true, $"Device({id}) is already attached.");
         }
 
-        var (_, ErrMsg) = await USBIPDWin.Attach(id, useBusID,force, isAuto, hostIP);
+        var (ErrCode, ErrMsg) = await USBIPDWin.Attach(id, useBusID, isAuto, hostIP);
+        await Task.Delay(500);
         await Update();
         if (IsAttached)
         {
             log.Info($"Success to attach {Description}({id}) to WSL {(string.IsNullOrWhiteSpace(hostIP) ? "" : "with " + hostIP)}.");
         }
-        else
+        else if (ErrCode != ErrorCode.Success)
         {
             log.Error($"Failed to attach {Description}({id}) to WSL {(string.IsNullOrWhiteSpace(hostIP) ? "" : "with " + hostIP)}: {ErrMsg}");
         }
@@ -245,13 +247,14 @@ public sealed class USBDevice
         {
             return (true, $"Device({id}) is already unbound.");
         }
-        var (_, ErrMsg) = await USBIPDWin.DetachDevice(id, useBusID);
+        var (ErrCode, ErrMsg) = await USBIPDWin.DetachDevice(id, useBusID);
+        await Task.Delay(500);
         await Update();
         if (!IsAttached)
         {
             log.Info($"Success to detach {Description}({id}) from WSL.");
         }
-        else
+        else if (ErrCode != ErrorCode.Success)
         {
             log.Error($"Failed to detach {Description}({id}) from WSL: {ErrMsg}");
         }

--- a/wsl-usb-manager/USBIPD/USBIPDWin.cs
+++ b/wsl-usb-manager/USBIPD/USBIPDWin.cs
@@ -52,6 +52,7 @@ public enum ErrorCode
     ParseError = 2,
     AccessDenied = 3,
     Timeout = 4,
+    DeviceInAttaching = 5,
     UnknownError = 255,
 };
 
@@ -329,7 +330,7 @@ public static partial class USBIPDWin
 
         try
         {
-            (ErrCode, StdOutput, StdError) = await RunProcessWithTimeout(process, daemon ? -1 : 5000);
+            (ErrCode, StdOutput, StdError) = await RunProcessWithTimeout(process, daemon ? -1 : 10000);
         }
         finally
         {
@@ -359,6 +360,11 @@ public static partial class USBIPDWin
                     index += 6;
                     StdError += $"{l[index..].Trim()}\r\n";
                 }
+                else if ((index = l.IndexOf("warning:")) >= 0)
+                {
+                    index += 8;
+                    StdError += $"{l[index..].Trim()}\r\n";
+                }
                 else
                 { StdOutput += l; }
             }
@@ -372,6 +378,11 @@ public static partial class USBIPDWin
                 else if ((index = l.IndexOf("error:")) >= 0)
                 {
                     index += 6;
+                    StdError += $"{l[index..].Trim()}\r\n";
+                }
+                else if ((index = l.IndexOf("warning:")) >= 0)
+                {
+                    index += 8;
                     StdError += $"{l[index..].Trim()}\r\n";
                 }
                 else { StdError += l; }


### PR DESCRIPTION


1. The force parameter has been removed from the Attach method in USBDeviceInfoModel, simplifying the method invocation logic.
2. Error handling in the Attach and Detach methods has been improved, with enhanced checks for error codes and messages.
3. A new error code DeviceInAttaching and related notifications have been added to handle cases where the device is occupied.
4. Log output has been optimized, with additional handling for warning messages and improved error message mapping logic.

Delays and status updates have been added during device operations to ensure state synchronization. Timeouts have been adjusted to accommodate longer operations, and forced attach logic has been removed. Redundant code has been cleaned up, and support for Chinese environments has been enhanced.